### PR TITLE
Fixes for Altera SoC

### DIFF
--- a/apps/common/src/system/system-c5socarm.c
+++ b/apps/common/src/system/system-c5socarm.c
@@ -353,18 +353,6 @@ static INT initializeDriver(void)
     DEBUG_LVL_ALWAYS_TRACE("INFO: driver Image size is %u bytes.\n", driverBinarySize);
     DEBUG_LVL_ALWAYS_TRACE("INFO: driver Executable start is %p\n", driverExecutableStartAddress);
 
-    // Release driver processor in reset
-    halRet = alt_fpga_gpo_write(0x00000001, 0x00000001);
-    if (halRet != ALT_E_SUCCESS)
-    {
-        return -1;
-    }
-
-    while (alt_fpga_gpi_read(0x00000001) != 0);
-
-    // Copy the driver image
-    memcpy(driverExecutableStartAddress, driverBinary, driverBinarySize);
-
     // Reset the driver processor
     halRet = alt_fpga_gpo_write(0x00000001, 0x00000000);
     if (halRet != ALT_E_SUCCESS)
@@ -373,6 +361,9 @@ static INT initializeDriver(void)
     }
 
     while (alt_fpga_gpi_read(0x00000001) == 0);
+
+    // Copy the driver image
+    memcpy(driverExecutableStartAddress, driverBinary, driverBinarySize);
 
     // Release the driver processor from reset
     halRet = alt_fpga_gpo_write(0x00000001, 0x00000001);

--- a/contrib/dualprocshm/include/dualprocshm-c5socarm.h
+++ b/contrib/dualprocshm/include/dualprocshm-c5socarm.h
@@ -84,7 +84,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // sleep
 #define DUALPROCSHM_USLEEP(x)           usleep((UINT32)x)
-#define DPSHM_DMB()                     // no data barriers used
+#define DPSHM_DMB()                     __asm("dmb")
 
 // IO operations
 #define DPSHM_READ8(base)               alt_read_byte((UINT32)base)

--- a/stack/include/oplk/targetdefs/c5socarm.h
+++ b/stack/include/oplk/targetdefs/c5socarm.h
@@ -121,7 +121,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define OPLK_IO_RD8(base, offset)           alt_read_byte((UINT)base + (UINT)offset)
 
 // Target memory barrier function
-#define OPLK_MEMBAR()
+#define OPLK_MEMBAR()                       __asm("dmb")
 
 /* NOTE:
  * ARM does not support atomic instructions, hence, pseudo atomic


### PR DESCRIPTION
This branch contains following fixes:
- Fix for processor hang during the initialization.
- Fix to include memory barriers for Cyclone V ARM.

Tested on:
Altera Cyclone V SoC