### PR TITLE
Rework tFrameInfo implementation to support heterogeneous systems

### DIFF
--- a/drivers/linux/drv_kernelmod_edrv/main.c
+++ b/drivers/linux/drv_kernelmod_edrv/main.c
@@ -663,7 +663,7 @@ static int sendAsyncFrame(unsigned long arg)
     }
 
     //TRACE("%s() Received frame size:%d\n", __func__, asyncFrame.size);
-    frameInfo.pFrame = (tPlkFrame*)pBuf;
+    frameInfo.frame.pBuffer = (tPlkFrame*)pBuf;
     frameInfo.frameSize = asyncFrameInfo.size;
 
     dllkcal_writeAsyncFrame(&frameInfo, asyncFrameInfo.queue);

--- a/stack/include/oplk/dll.h
+++ b/stack/include/oplk/dll.h
@@ -160,7 +160,17 @@ typedef struct
 {
     UINT            frameSize;                      ///< Size of the frame
     UINT32          padding1;                       ///< Padding variable 1
-    tPlkFrame*      pFrame;                         ///< Pointer to the frame
+    // Use a union of tPlkFrame pointer variable and 64 bit
+    // variable to avoid corruption of pointer variable in
+    // heteregenous processor system. The padding2 variable is
+    // used to reserve 8 bytes memory for pBuffer and
+    // to ensure that garbage value is cleared before sharing
+    // the pointer variable.
+    union
+    {
+        tPlkFrame*      pBuffer;                   ///< Pointer to the frame buffer
+        UINT64          padding2;                  ///< 64 bit place holder
+    } frame;
 } tFrameInfo;
 
 /**

--- a/stack/src/kernel/dll/dllkevent.c
+++ b/stack/src/kernel/dll/dllkevent.c
@@ -908,7 +908,7 @@ static tOplkError processSyncCn(tNmtState nmtState_p, BOOL fReadyFlag_p)
         if (nmtState_p != kNmtCsOperational)
             fReadyFlag_p = FALSE;
 
-        FrameInfo.pFrame = pTxFrame;
+        FrameInfo.frame.pBuffer = pTxFrame;
         FrameInfo.frameSize = pTxBuffer->txFrameSize;
         ret = dllkframe_processTpdo(&FrameInfo, fReadyFlag_p);
         if (ret != kErrorOk)

--- a/stack/src/kernel/dll/dllkframe.c
+++ b/stack/src/kernel/dll/dllkframe.c
@@ -233,7 +233,7 @@ tEdrvReleaseRxBuffer dllkframe_processFrameReceived(tEdrvRxBuffer* pRxBuffer_p)
     }
 #endif
 
-    frameInfo.pFrame = pFrame;
+    frameInfo.frame.pBuffer = pFrame;
     frameInfo.frameSize = pRxBuffer_p->rxFrameSize;
 
     if (ami_getUint16Be(&pFrame->etherType) != C_DLL_ETHERTYPE_EPL)
@@ -1748,7 +1748,7 @@ static tOplkError processReceivedPreq(tFrameInfo* pFrameInfo_p, tNmtState nmtSta
     tPlkFrame*      pFrame;
     BYTE            bFlag1;
 
-    pFrame = pFrameInfo_p->pFrame;
+    pFrame = pFrameInfo_p->frame.pBuffer;
 
     if (!NMT_IF_ACTIVE_CN(nmtState_p))
     {   // MN is active -> wrong msg type
@@ -1847,7 +1847,7 @@ The function checks if a PRes frame is invalid.
 static BOOL presFrameFormatIsInvalid(tFrameInfo* pFrameInfo_p, tDllkNodeInfo* pIntNodeInfo_p,
                                      tNmtState nodeNmtState_p)
 {
-    tPlkFrame*  pFrame = pFrameInfo_p->pFrame;
+    tPlkFrame*  pFrame = pFrameInfo_p->frame.pBuffer;
     size_t      frameSize = pFrameInfo_p->frameSize;
     size_t      payloadSize = ami_getUint16Le(&pFrame->data.pres.sizeLe);
 
@@ -1904,7 +1904,7 @@ static tOplkError processReceivedPres(tFrameInfo* pFrameInfo_p, tNmtState nmtSta
     tDllkPresFw*    pPresFw;
 #endif
 
-    pFrame = pFrameInfo_p->pFrame;
+    pFrame = pFrameInfo_p->frame.pBuffer;
     nodeId = ami_getUint8Le(&pFrame->srcNodeId);
 
 #if defined(CONFIG_INCLUDE_NMT_MN) && defined(CONFIG_INCLUDE_PRES_FORWARD)
@@ -2573,7 +2573,7 @@ static tOplkError processReceivedAsnd(tFrameInfo* pFrameInfo_p, tEdrvRxBuffer* p
     UNUSED_PARAMETER(pRxBuffer_p);
 #endif
 
-    pFrame = pFrameInfo_p->pFrame;
+    pFrame = pFrameInfo_p->frame.pBuffer;
 
     // ASnd service registered?
     asndServiceId = (UINT)ami_getUint8Le(&pFrame->data.asnd.serviceId);

--- a/stack/src/kernel/dll/dllknode.c
+++ b/stack/src/kernel/dll/dllknode.c
@@ -775,7 +775,7 @@ tOplkError dllknode_setupSyncPhase(tNmtState nmtState_p, BOOL fReadyFlag_p,
             ami_setUint8Le(&pTxFrame->data.preq.flag1, flag1);
 
             // process TPDO
-            FrameInfo.pFrame = pTxFrame;
+            FrameInfo.frame.pBuffer = pTxFrame;
             FrameInfo.frameSize = pTxBuffer->txFrameSize;
             ret = dllkframe_processTpdo(&FrameInfo, fReadyFlag_p);
             if (ret != kErrorOk)

--- a/stack/src/kernel/pdo/pdok.c
+++ b/stack/src/kernel/pdo/pdok.c
@@ -544,7 +544,7 @@ NMT_CS_OPERATIONAL.
 static tOplkError cbProcessTpdo(tFrameInfo* pFrameInfo_p, BOOL fReadyFlag_p)
 {
     tOplkError      Ret = kErrorOk;
-    Ret = copyTxPdo(pFrameInfo_p->pFrame, pFrameInfo_p->frameSize, fReadyFlag_p);
+    Ret = copyTxPdo(pFrameInfo_p->frame.pBuffer, pFrameInfo_p->frameSize, fReadyFlag_p);
     return Ret;
 }
 

--- a/stack/src/kernel/pdo/pdokcal.c
+++ b/stack/src/kernel/pdo/pdokcal.c
@@ -180,7 +180,7 @@ tOplkError pdokcal_process(tEvent* pEvent_p)
 #if CONFIG_DLL_DEFERRED_RXFRAME_RELEASE_SYNC != FALSE
                 tFrameInfo*  pFrameInfo;
                 pFrameInfo = (tFrameInfo*)pEvent_p->eventArg.pEventArg;
-                Ret = pdok_processRxPdo(pFrameInfo->pFrame, pFrameInfo->frameSize);
+                Ret = pdok_processRxPdo(pFrameInfo->frame.pBuffer, pFrameInfo->frameSize);
 #else
                 tPlkFrame* pFrame;
 
@@ -234,9 +234,9 @@ static tOplkError cbProcessRpdo(tFrameInfo* pFrameInfo_p)
     event.eventArg.pEventArg = pFrameInfo_p;
 #else
     // limit copied data to size of PDO (because from some CNs the frame is larger than necessary)
-    event.eventArgSize = ami_getUint16Le(&pFrameInfo_p->pFrame->data.pres.sizeLe) +
+    event.eventArgSize = ami_getUint16Le(&pFrameInfo_p->frame.pBuffer->data.pres.sizeLe) +
                                          PLK_FRAME_OFFSET_PDO_PAYLOAD; // pFrameInfo_p->frameSize;
-    event.eventArg.pEventArg = pFrameInfo_p->pFrame;
+    event.eventArg.pEventArg = pFrameInfo_p->frame.pBuffer;
 #endif
     ret = eventk_postEvent(&event);
 #if CONFIG_DLL_DEFERRED_RXFRAME_RELEASE_SYNC != FALSE

--- a/stack/src/kernel/veth/veth-linuxkernel.c
+++ b/stack/src/kernel/veth/veth-linuxkernel.c
@@ -271,7 +271,7 @@ static int veth_xmit(struct sk_buff* pSkb_p, struct net_device* pNetDevice_p)
     //save timestemp
     pNetDevice_p->trans_start = jiffies;
 
-    frameInfo.pFrame = (tPlkFrame*)pSkb_p->data;
+    frameInfo.frame.pBuffer = (tPlkFrame*)pSkb_p->data;
     frameInfo.frameSize = pSkb_p->len;
 
     //call send fkt on DLL
@@ -365,7 +365,7 @@ static tOplkError veth_receiveFrame(tFrameInfo* pFrameInfo_p,
 
     skb_reserve(pSkb, 2);
 
-    OPLK_MEMCPY((void*)skb_put(pSkb, pFrameInfo_p->frameSize), pFrameInfo_p->pFrame, pFrameInfo_p->frameSize);
+    OPLK_MEMCPY((void*)skb_put(pSkb, pFrameInfo_p->frameSize), pFrameInfo_p->frame.pBuffer, pFrameInfo_p->frameSize);
 
     pSkb->protocol = eth_type_trans(pSkb, pNetDevice);
     pSkb->ip_summed = CHECKSUM_UNNECESSARY;
@@ -373,12 +373,12 @@ static tOplkError veth_receiveFrame(tFrameInfo* pFrameInfo_p,
     netif_rx(pSkb);         // call netif_rx with skb
 
     DEBUG_LVL_VETH_TRACE("veth_receiveFrame: SrcMAC: %02X:%02X:%02x:%02X:%02X:%02x\n",
-                         pFrameInfo_p->pFrame->aSrcMac[0],
-                         pFrameInfo_p->pFrame->aSrcMac[1],
-                         pFrameInfo_p->pFrame->aSrcMac[2],
-                         pFrameInfo_p->pFrame->aSrcMac[3],
-                         pFrameInfo_p->pFrame->aSrcMac[4],
-                         pFrameInfo_p->pFrame->aSrcMac[5]);
+                         pFrameInfo_p->frame.pBuffer->aSrcMac[0],
+                         pFrameInfo_p->frame.pBuffer->aSrcMac[1],
+                         pFrameInfo_p->frame.pBuffer->aSrcMac[2],
+                         pFrameInfo_p->frame.pBuffer->aSrcMac[3],
+                         pFrameInfo_p->frame.pBuffer->aSrcMac[4],
+                         pFrameInfo_p->frame.pBuffer->aSrcMac[5]);
 
     // update receive statistics
     pStats->rx_packets++;

--- a/stack/src/kernel/veth/veth-linuxuser.c
+++ b/stack/src/kernel/veth/veth-linuxuser.c
@@ -272,12 +272,12 @@ static tOplkError veth_receiveFrame(tFrameInfo* pFrameInfo_p,
 
     // replace the MAC address of the POWERLINK Ethernet interface with virtual
     // Ethernet MAC address before forwarding it into the virtual Ethernet interface
-    if (OPLK_MEMCMP(pFrameInfo_p->pFrame->aDstMac, vethInstance_l.macAdrs, ETHER_ADDR_LEN) == 0)
+    if (OPLK_MEMCMP(pFrameInfo_p->frame.pBuffer->aDstMac, vethInstance_l.macAdrs, ETHER_ADDR_LEN) == 0)
     {
-        OPLK_MEMCPY(pFrameInfo_p->pFrame->aDstMac, vethInstance_l.tapMacAdrs, ETHER_ADDR_LEN);
+        OPLK_MEMCPY(pFrameInfo_p->frame.pBuffer->aDstMac, vethInstance_l.tapMacAdrs, ETHER_ADDR_LEN);
     }
 
-    nwrite = write(vethInstance_l.fd, pFrameInfo_p->pFrame, pFrameInfo_p->frameSize);
+    nwrite = write(vethInstance_l.fd, pFrameInfo_p->frame.pBuffer, pFrameInfo_p->frameSize);
     if (nwrite != pFrameInfo_p->frameSize)
     {
         DEBUG_LVL_VETH_TRACE("Error writing data to virtual Ethernet interface!\n");
@@ -342,7 +342,7 @@ static void* vethRecvThread(void* pArg_p)
                     // replace src MAC address with MAC address of virtual Ethernet interface
                     OPLK_MEMCPY(&buffer[6], pInstance->macAdrs, ETHER_ADDR_LEN);
 
-                    frameInfo.pFrame = (tPlkFrame *)buffer;
+                    frameInfo.frame.pBuffer = (tPlkFrame *)buffer;
                     frameInfo.frameSize = nread;
                     ret = dllkcal_sendAsyncFrame(&frameInfo, kDllAsyncReqPrioGeneric);
                     if (ret != kErrorOk)

--- a/stack/src/user/api/generic.c
+++ b/stack/src/user/api/generic.c
@@ -727,16 +727,16 @@ tOplkError oplk_sendAsndFrame(UINT8 dstNodeId_p, tAsndFrame* pAsndFrame_p,
 
     // Set up frame info
     frameInfo.frameSize = frameSize;
-    frameInfo.pFrame = (tPlkFrame*)buffer;
+    frameInfo.frame.pBuffer = (tPlkFrame*)buffer;
 
     // Copy Asnd data
-    OPLK_MEMSET(frameInfo.pFrame, 0x00, frameInfo.frameSize);
-    OPLK_MEMCPY(&frameInfo.pFrame->data.asnd, pAsndFrame_p, asndSize_p);
+    OPLK_MEMSET(frameInfo.frame.pBuffer, 0x00, frameInfo.frameSize);
+    OPLK_MEMCPY(&frameInfo.frame.pBuffer->data.asnd, pAsndFrame_p, asndSize_p);
 
     // Fill in additional data (SrcNodeId is filled by DLL if it is set to 0)
-    ami_setUint8Le(&frameInfo.pFrame->messageType, (UINT8)kMsgTypeAsnd);
-    ami_setUint8Le(&frameInfo.pFrame->dstNodeId, (UINT8)dstNodeId_p);
-    ami_setUint8Le(&frameInfo.pFrame->srcNodeId, (UINT8)0);
+    ami_setUint8Le(&frameInfo.frame.pBuffer->messageType, (UINT8)kMsgTypeAsnd);
+    ami_setUint8Le(&frameInfo.frame.pBuffer->dstNodeId, (UINT8)dstNodeId_p);
+    ami_setUint8Le(&frameInfo.frame.pBuffer->srcNodeId, (UINT8)0);
 
     // Request frame transmission
     ret = dllucal_sendAsyncFrame(&frameInfo, kDllAsyncReqPrioGeneric);
@@ -781,7 +781,7 @@ tOplkError oplk_sendEthFrame(tPlkFrame* pFrame_p, UINT frameSize_p)
 
     // Set frame info
     frameInfo.frameSize = frameSize_p;
-    frameInfo.pFrame = pFrame_p;
+    frameInfo.frame.pBuffer = pFrame_p;
 
     // Forward frame to DLLuCAL
     ret = dllucal_sendAsyncFrame(&frameInfo, kDllAsyncReqPrioGeneric);
@@ -1293,7 +1293,7 @@ static tOplkError cbReceivedAsnd(tFrameInfo* pFrameInfo_p)
         return kErrorReject;
 
     // Forward received ASnd frame
-    apiEventArg.receivedAsnd.pFrame = pFrameInfo_p->pFrame;
+    apiEventArg.receivedAsnd.pFrame = pFrameInfo_p->frame.pBuffer;
     apiEventArg.receivedAsnd.frameSize = pFrameInfo_p->frameSize;
 
     eventType = kOplkApiEventReceivedAsnd;
@@ -1319,7 +1319,7 @@ static tOplkError cbReceivedEth(tFrameInfo* pFrameInfo_p)
     tOplkError          ret = kErrorOk;
     tOplkApiEventArg    eventArg;
 
-    eventArg.receivedEth.pFrame = pFrameInfo_p->pFrame;
+    eventArg.receivedEth.pFrame = pFrameInfo_p->frame.pBuffer;
     eventArg.receivedEth.frameSize = pFrameInfo_p->frameSize;
 
     ret = ctrlu_callUserEventCallback(kOplkApiEventReceivedNonPlk, &eventArg);

--- a/stack/src/user/dll/dllucal.c
+++ b/stack/src/user/dll/dllucal.c
@@ -260,7 +260,7 @@ tOplkError dllucal_process(tEvent* pEvent_p)
     {
         case kEventTypeAsndRx:
             // Argument pointer is frame
-            FrameInfo.pFrame = (tPlkFrame*)pEvent_p->eventArg.pEventArg;
+            FrameInfo.frame.pBuffer = (tPlkFrame*)pEvent_p->eventArg.pEventArg;
             FrameInfo.frameSize = pEvent_p->eventArgSize;
             pFrameInfo = &FrameInfo;
             ret = handleRxAsyncFrame(pFrameInfo);
@@ -434,7 +434,7 @@ tOplkError dllucal_sendAsyncFrame(tFrameInfo* pFrameInfo_p,
         case kDllAsyncReqPrioNmt:
             ret = instance_l.pTxNmtFuncs->pfnInsertDataBlock(
                                         instance_l.dllCalQueueTxNmt,
-                                        (BYTE*)pFrameInfo_p->pFrame,
+                                        (BYTE*)pFrameInfo_p->frame.pBuffer,
                                         &(pFrameInfo_p->frameSize));
             break;
 
@@ -674,7 +674,7 @@ on the frame type (e.g. POWERLINK or non-POWERLINK frames).
 static tOplkError handleRxAsyncFrame(tFrameInfo* pFrameInfo_p)
 {
     tOplkError  ret = kErrorOk;
-    UINT16      etherType = ami_getUint16Be(&pFrameInfo_p->pFrame->etherType);
+    UINT16      etherType = ami_getUint16Be(&pFrameInfo_p->frame.pBuffer->etherType);
 
     switch (etherType)
     {
@@ -715,14 +715,14 @@ static tOplkError handleRxAsndFrame(tFrameInfo *pFrameInfo_p)
     unsigned int    asndServiceId;
     tOplkError      ret = kErrorOk;
 
-    msgType = (tMsgType)ami_getUint8Le(&pFrameInfo_p->pFrame->messageType);
+    msgType = (tMsgType)ami_getUint8Le(&pFrameInfo_p->frame.pBuffer->messageType);
     if (msgType != kMsgTypeAsnd)
     {
         ret = kErrorInvalidOperation;
         goto Exit;
     }
 
-    asndServiceId = (unsigned int)ami_getUint8Le(&pFrameInfo_p->pFrame->data.asnd.serviceId);
+    asndServiceId = (unsigned int)ami_getUint8Le(&pFrameInfo_p->frame.pBuffer->data.asnd.serviceId);
     if (asndServiceId < DLL_MAX_ASND_SERVICE_ID)
     {   // ASnd service ID is valid
         if (instance_l.apfnDlluCbAsnd[asndServiceId] != NULL)
@@ -751,7 +751,7 @@ static tOplkError handleRxAsyncFrameInfo(tFrameInfo* pFrameInfo_p)
 {
     tOplkError      ret;
     tEvent          event;
-    tPlkFrame*      pKernelBuffer = pFrameInfo_p->pFrame;
+    tPlkFrame*      pKernelBuffer = pFrameInfo_p->frame.pBuffer;
     tPlkFrame*      pAcqBuffer;
 
     // Get Rx buffer from kernel layer
@@ -763,7 +763,7 @@ static tOplkError handleRxAsyncFrameInfo(tFrameInfo* pFrameInfo_p)
     }
 
     // Set reference to kernel buffer for processing
-    pFrameInfo_p->pFrame = pAcqBuffer;
+    pFrameInfo_p->frame.pBuffer = pAcqBuffer;
 
     // Now handle the async frame
     ret = handleRxAsyncFrame(pFrameInfo_p);
@@ -772,7 +772,7 @@ static tOplkError handleRxAsyncFrameInfo(tFrameInfo* pFrameInfo_p)
     memmap_unmapKernelBuffer(pAcqBuffer);
 
     // Restore frame info for releasing Rx frame
-    pFrameInfo_p->pFrame = pKernelBuffer;
+    pFrameInfo_p->frame.pBuffer = pKernelBuffer;
 
     // call free function for Asnd frame
     event.eventSink = kEventSinkDllkCal;
@@ -808,7 +808,7 @@ static tOplkError handleNotRxAsndFrame(tDllAsndNotRx* pAsndNotRx_p)
     ami_setUint8Le(&pFrame->data.asnd.serviceId, pAsndNotRx_p->serviceId);
 
     frameInfo.frameSize = DLLUCAL_NOTRX_FRAME_SIZE;
-    frameInfo.pFrame = pFrame;
+    frameInfo.frame.pBuffer = pFrame;
 
     asndServiceId = (UINT)ami_getUint8Le(&pFrame->data.asnd.serviceId);
     if (asndServiceId < DLL_MAX_ASND_SERVICE_ID)
@@ -841,13 +841,13 @@ Ethernet Tx queue.
 static tOplkError sendGenericAsyncFrame(tFrameInfo* pFrameInfo_p)
 {
     tOplkError  ret = kErrorOk;
-    UINT16      etherType = ami_getUint16Be(&pFrameInfo_p->pFrame->etherType);
+    UINT16      etherType = ami_getUint16Be(&pFrameInfo_p->frame.pBuffer->etherType);
 
     if (etherType == 0 || etherType == C_DLL_ETHERTYPE_EPL)
     {
         ret = instance_l.pTxGenFuncs->pfnInsertDataBlock(
                                     instance_l.dllCalQueueTxGen,
-                                    (BYTE*)pFrameInfo_p->pFrame,
+                                    (BYTE*)pFrameInfo_p->frame.pBuffer,
                                     &(pFrameInfo_p->frameSize));
     }
     else
@@ -855,7 +855,7 @@ static tOplkError sendGenericAsyncFrame(tFrameInfo* pFrameInfo_p)
 #if defined(CONFIG_INCLUDE_VETH)
         ret = instance_l.pTxVethFuncs->pfnInsertDataBlock(
                                     instance_l.dllCalQueueTxVeth,
-                                    (UINT8*)pFrameInfo_p->pFrame,
+                                    (UINT8*)pFrameInfo_p->frame.pBuffer,
                                     &(pFrameInfo_p->frameSize));
 #else
     // Return error since virtual Ethernet is not existing!

--- a/stack/src/user/nmt/identu.c
+++ b/stack/src/user/nmt/identu.c
@@ -321,7 +321,7 @@ static tOplkError identu_cbIdentResponse(tFrameInfo* pFrameInfo_p)
     UINT                    index;
     tIdentuCbResponse       pfnCbResponse;
 
-    nodeId = ami_getUint8Le(&pFrameInfo_p->pFrame->srcNodeId);
+    nodeId = ami_getUint8Le(&pFrameInfo_p->frame.pBuffer->srcNodeId);
     index = nodeId - 1;
 
     if (index < tabentries(instance_g.apfnCbResponse))
@@ -346,14 +346,14 @@ static tOplkError identu_cbIdentResponse(tFrameInfo* pFrameInfo_p)
                 if (instance_g.apIdentResponse[index] == NULL)
                 {   // malloc failed
                     ret = pfnCbResponse(nodeId,
-                                        &pFrameInfo_p->pFrame->data.asnd.payload.identResponse);
+                                        &pFrameInfo_p->frame.pBuffer->data.asnd.payload.identResponse);
                     goto Exit;
                 }
             }
 
             // copy IdentResponse to instance structure
             OPLK_MEMCPY(instance_g.apIdentResponse[index],
-                        &pFrameInfo_p->pFrame->data.asnd.payload.identResponse,
+                        &pFrameInfo_p->frame.pBuffer->data.asnd.payload.identResponse,
                         sizeof(tIdentResponse));
             ret = pfnCbResponse(nodeId, instance_g.apIdentResponse[index]);
         }

--- a/stack/src/user/nmt/nmtcnu.c
+++ b/stack/src/user/nmt/nmtcnu.c
@@ -219,7 +219,7 @@ tOplkError nmtcnu_sendNmtRequestEx(UINT nodeId_p, tNmtCommand nmtCommand_p,
     }
 
     // build info-structure
-    nmtRequestFrameInfo.pFrame = &nmtRequestFrame;
+    nmtRequestFrameInfo.frame.pBuffer = &nmtRequestFrame;
     nmtRequestFrameInfo.frameSize = C_DLL_MINSIZE_NMTREQ; // sizeof(nmtRequestFrame);
 
     // send NMT request
@@ -316,7 +316,7 @@ static tOplkError commandCb(tFrameInfo* pFrameInfo_p)
         // extended NMT state commands
         case kNmtCmdStartNodeEx:
             // check if own nodeid is in the POWERLINK node list
-            fNodeIdInList = checkNodeIdList(&(pFrameInfo_p->pFrame->data.asnd.payload.nmtCommandService.aNmtCommandData[0]));
+            fNodeIdInList = checkNodeIdList(&(pFrameInfo_p->frame.pBuffer->data.asnd.payload.nmtCommandService.aNmtCommandData[0]));
             if (fNodeIdInList != FALSE)
             {   // own nodeid in list
                 // send event to process command
@@ -326,7 +326,7 @@ static tOplkError commandCb(tFrameInfo* pFrameInfo_p)
 
         case kNmtCmdStopNodeEx:
             // check if own nodeid is in the POWERLINK node list
-            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->pFrame->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
+            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->frame.pBuffer->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
             if (fNodeIdInList != FALSE)
             {   // own nodeid in list
                 // send event to process command
@@ -336,7 +336,7 @@ static tOplkError commandCb(tFrameInfo* pFrameInfo_p)
 
         case kNmtCmdEnterPreOperational2Ex:
             // check if own nodeid is in the POWERLINK node list
-            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->pFrame->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
+            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->frame.pBuffer->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
             if (fNodeIdInList != FALSE)
             {   // own nodeid in list
                 // send event to process command
@@ -346,7 +346,7 @@ static tOplkError commandCb(tFrameInfo* pFrameInfo_p)
 
         case kNmtCmdEnableReadyToOperateEx:
             // check if own nodeid is in the POWERLINK node list
-            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->pFrame->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
+            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->frame.pBuffer->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
             if (fNodeIdInList != FALSE)
             {   // own nodeid in list
                 // send event to process command
@@ -356,7 +356,7 @@ static tOplkError commandCb(tFrameInfo* pFrameInfo_p)
 
         case kNmtCmdResetNodeEx:
             // check if own nodeid is in the POWERLINK node list
-            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->pFrame->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
+            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->frame.pBuffer->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
             if (fNodeIdInList != FALSE)
             {   // own nodeid in list
                 // send event to process command
@@ -366,7 +366,7 @@ static tOplkError commandCb(tFrameInfo* pFrameInfo_p)
 
         case kNmtCmdResetCommunicationEx:
             // check if own nodeid is in the POWERLINK node list
-            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->pFrame->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
+            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->frame.pBuffer->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
             if (fNodeIdInList != FALSE)
             {   // own nodeid in list
                 // send event to process command
@@ -376,7 +376,7 @@ static tOplkError commandCb(tFrameInfo* pFrameInfo_p)
 
         case kNmtCmdResetConfigurationEx:
             // check if own nodeid is in the POWERLINK node list
-            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->pFrame->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
+            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->frame.pBuffer->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
             if (fNodeIdInList != FALSE)
             {   // own nodeid in list
                 // send event to process command
@@ -386,7 +386,7 @@ static tOplkError commandCb(tFrameInfo* pFrameInfo_p)
 
         case kNmtCmdSwResetEx:
             // check if own nodeid is in the POWERLINK node list
-            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->pFrame->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
+            fNodeIdInList = checkNodeIdList(&pFrameInfo_p->frame.pBuffer->data.asnd.payload.nmtCommandService.aNmtCommandData[0]);
             if (fNodeIdInList != FALSE)
             {   // own nodeid in list
                 // send event to process command
@@ -483,7 +483,7 @@ static tNmtCommand getNmtCommand(tFrameInfo* pFrameInfo_p)
     tNmtCommand          nmtCommand;
     tNmtCommandService*  pNmtCommandService;
 
-    pNmtCommandService = &pFrameInfo_p->pFrame->data.asnd.payload.nmtCommandService;
+    pNmtCommandService = &pFrameInfo_p->frame.pBuffer->data.asnd.payload.nmtCommandService;
     nmtCommand = (tNmtCommand)ami_getUint8Le(&pNmtCommandService->nmtCommandId);
 
     return nmtCommand;

--- a/stack/src/user/nmt/nmtmnu.c
+++ b/stack/src/user/nmt/nmtmnu.c
@@ -1466,10 +1466,10 @@ static tOplkError cbNmtRequest(tFrameInfo* pFrameInfo_p)
     UINT                    sourceNodeId;
     UINT                    commandSize;
 
-    if ((pFrameInfo_p == NULL) || (pFrameInfo_p->pFrame == NULL))
+    if ((pFrameInfo_p == NULL) || (pFrameInfo_p->frame.pBuffer == NULL))
         return kErrorNmtInvalidFramePointer;
 
-    pNmtRequestService = &pFrameInfo_p->pFrame->data.asnd.payload.nmtRequestService;
+    pNmtRequestService = &pFrameInfo_p->frame.pBuffer->data.asnd.payload.nmtRequestService;
     nmtCommand = (tNmtCommand)ami_getUint8Le(&pNmtRequestService->nmtCommandId);
     targetNodeId = ami_getUint8Le(&pNmtRequestService->targetNodeId);
     commandSize = min(sizeof(pNmtRequestService->aNmtCommandData),
@@ -1478,7 +1478,7 @@ static tOplkError cbNmtRequest(tFrameInfo* pFrameInfo_p)
                                    pNmtRequestService->aNmtCommandData, commandSize);
     if (ret != kErrorOk)
     {   // error -> reply with kNmtCmdInvalidService
-        sourceNodeId = ami_getUint8Le(&pFrameInfo_p->pFrame->srcNodeId);
+        sourceNodeId = ami_getUint8Le(&pFrameInfo_p->frame.pBuffer->srcNodeId);
         ret = nmtmnu_sendNmtCommand(sourceNodeId, kNmtCmdInvalidService);
         if (ret == kErrorInvalidOperation)
             ret = kErrorOk;
@@ -4759,7 +4759,7 @@ static tOplkError sendNmtCommand(UINT nodeId_p, tNmtCommand nmtCommand_p,
     }
 
     // build info structure
-    frameInfo.pFrame = pFrame;
+    frameInfo.frame.pBuffer = pFrame;
     frameInfo.frameSize = sizeof(aBuffer);
 
     // send NMT-Request

--- a/stack/src/user/nmt/statusu.c
+++ b/stack/src/user/nmt/statusu.c
@@ -240,7 +240,7 @@ static tOplkError statusu_cbStatusResponse(tFrameInfo* pFrameInfo_p)
     UINT                index;
     tStatusuCbResponse  pfnCbResponse;
 
-    nodeId = ami_getUint8Le(&pFrameInfo_p->pFrame->srcNodeId);
+    nodeId = ami_getUint8Le(&pFrameInfo_p->frame.pBuffer->srcNodeId);
     index = nodeId - 1;
 
     if (index < tabentries(instance_g.apfnCbResponse))
@@ -260,7 +260,7 @@ static tOplkError statusu_cbStatusResponse(tFrameInfo* pFrameInfo_p)
         }
         else
         {   // StatusResponse received
-            ret = pfnCbResponse(nodeId, &pFrameInfo_p->pFrame->data.asnd.payload.statusResponse);
+            ret = pfnCbResponse(nodeId, &pFrameInfo_p->frame.pBuffer->data.asnd.payload.statusResponse);
         }
     }
 

--- a/stack/src/user/nmt/syncu.c
+++ b/stack/src/user/nmt/syncu.c
@@ -251,7 +251,7 @@ static tOplkError syncResponseCb(tFrameInfo* pFrameInfo_p)
     UINT                index;
     tSyncuCbResponse    pfnCbResponse;
 
-    nodeId = ami_getUint8Le(&pFrameInfo_p->pFrame->srcNodeId);
+    nodeId = ami_getUint8Le(&pFrameInfo_p->frame.pBuffer->srcNodeId);
     index  = nodeId - 1;
 
     if (index < tabentries(syncuInstance_g.aSyncRespQueue))
@@ -269,7 +269,7 @@ static tOplkError syncResponseCb(tFrameInfo* pFrameInfo_p)
         }
         else
         {   // SyncResponse received
-            ret = pfnCbResponse(nodeId, &pFrameInfo_p->pFrame->data.asnd.payload.syncResponse);
+            ret = pfnCbResponse(nodeId, &pFrameInfo_p->frame.pBuffer->data.asnd.payload.syncResponse);
         }
     }
     return ret;

--- a/stack/src/user/sdo/sdoasnd.c
+++ b/stack/src/user/sdo/sdoasnd.c
@@ -256,7 +256,7 @@ tOplkError sdoasnd_sendData(tSdoConHdl sdoConHandle_p, tPlkFrame* pSrcData_p, UI
 
     // send function of DLL
     frameInfo.frameSize = dataSize_p;
-    frameInfo.pFrame = pSrcData_p;
+    frameInfo.frame.pBuffer = pSrcData_p;
 
     ret = dllucal_sendAsyncFrame(&frameInfo, kDllAsyncReqPrioGeneric);
     if (ret == kErrorDllAsyncTxBufferFull)
@@ -325,7 +325,7 @@ static tOplkError sdoAsndCb(tFrameInfo* pFrameInfo_p)
     tSdoConHdl      sdoConHdl;
     tPlkFrame*      pFrame;
 
-    pFrame = pFrameInfo_p->pFrame;
+    pFrame = pFrameInfo_p->frame.pBuffer;
     nodeId = ami_getUint8Le(&pFrame->srcNodeId);
 
     // search corresponding entry in control structure


### PR DESCRIPTION
This is an additional commit for support of heterogeneous systems.

Commit revises the implementation of tFrameInfo structure to use union to avoid corruption of pointer between the processors.

Compiled on:
1. Linux
2. Windows
3. Xilinx Zynq board
4. APC2100 Windows PCIe design

Tested on:
APC2100