### PR TITLE
[FIX] remove __DATE__ and __TIME__

### DIFF
--- a/drivers/linux/drv_kernelmod_edrv/main.c
+++ b/drivers/linux/drv_kernelmod_edrv/main.c
@@ -201,7 +201,6 @@ static int __init powerlinkInit(void)
 {
     int  err;
 
-    DEBUG_LVL_ALWAYS_TRACE("PLK: powerlinkInit()  Driver build: %s / %s\n", __DATE__, __TIME__);
     DEBUG_LVL_ALWAYS_TRACE("PLK: powerlinkInit()  Stack version: %s\n", PLK_DEFINED_STRING_VERSION);
     plkDev_g = 0;
     atomic_set(&openCount_g, 0);


### PR DESCRIPTION
Hello,

With gcc 4.9 and a linux 3.18+ the build stop on the following error:

drivers/linux/drv_kernelmod_edrv/src/main.c:204:95: error: macro "__DATE__" might prevent reproducible builds [-Werror=date-time]
     DEBUG_LVL_ALWAYS_TRACE("PLK: powerlinkInit()  Driver build: %s / %s\n", __DATE__, __TIME__);
                                                                                               ^
drivers/linux/drv_kernelmod_edrv/src/main.c:204:1: error: macro "__TIME__" might prevent reproducible builds [-Werror=date-time]
     DEBUG_LVL_ALWAYS_TRACE("PLK: powerlinkInit()  Driver build: %s / %s\n", __DATE__, __TIME__);
 ^
cc1: some warnings being treated as errors

Remove __DATE__ and __TIME__ usage since the most important thing
is the oplk stack version.

Best regards,
Romain