### PR TITLE
[FIX] warn if ARCH or CROSS_COMPILE are not set when cross-compiling.

### DIFF
--- a/drivers/linux/drv_kernelmod_edrv/CMakeLists.txt
+++ b/drivers/linux/drv_kernelmod_edrv/CMakeLists.txt
@@ -263,11 +263,17 @@ CONFIGURE_FILE(${TOOLS_DIR}/linux/Kbuild.in ${MODULE_OUTPUT_DIR}/Kbuild)
 IF(CMAKE_CROSSCOMPILING)
     IF(DEFINED MAKE_KERNEL_ARCH)
         SET(MAKE_KERNEL_CROSSCOMPILING_PARAMS ARCH=${MAKE_KERNEL_ARCH})
+    ELSE()
+        MESSAGE(WARNING "ARCH is not set while cross-compiling !\n"
+            "Set MAKE_KERNEL_ARCH with your target architecture.")
     ENDIF()
 
     IF(DEFINED MAKE_KERNEL_CROSS_COMPILE)
         SET(MAKE_KERNEL_CROSSCOMPILING_PARAMS
                 ${MAKE_KERNEL_CROSSCOMPILING_PARAMS} CROSS_COMPILE=${MAKE_KERNEL_CROSS_COMPILE})
+    ELSE()
+        MESSAGE(WARNING "CROSS_COMPILE is not set while cross-compiling !\n"
+            "Set MAKE_KERNEL_CROSS_COMPILE with your toolchain prefix")
     ENDIF()
 ENDIF()
 


### PR DESCRIPTION
Hi,

I get a build failure due to host gcc being used while cross-compiling.
I would suggest to add these warning in the build system.

Thanks,
Romain 