### PR TITLE
[FIX] disable Werror=date-time for kernel >= 3.14

### DIFF
--- a/drivers/linux/drv_kernelmod_edrv/CMakeLists.txt
+++ b/drivers/linux/drv_kernelmod_edrv/CMakeLists.txt
@@ -47,6 +47,9 @@ MESSAGE(STATUS "CMAKE_SYSTEM_PROCESSOR is ${CMAKE_SYSTEM_PROCESSOR}")
 STRING(TOLOWER "${CMAKE_SYSTEM_NAME}" SYSTEM_NAME_DIR)
 STRING(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" SYSTEM_PROCESSOR_DIR)
 
+# Since 3.14 kernel Werror=date-time is automatically used if the compiler support it.
+SET(MODULE_DEFS "${MODULE_DEFS} -Wno-date-time")
+
 ################################################################################
 # Configuration options
 


### PR DESCRIPTION
Hi,

Avoid a build error due to __DATE__ and __TIME___ being used in
oplk driver. Just disable the warning with -Wno-date-time.

https://github.com/openPOWERLINK/openPOWERLINK_V2/pull/58

Tested with a gcc 4.7 and 4.9.

Best regards,
Romain