### PR TITLE
Documentation for Windows PCIe solution

### DIFF
--- a/doc/build-demos.md
+++ b/doc/build-demos.md
@@ -142,13 +142,20 @@ Follow the steps below to cross compile your demo application for Altera Cyclone
 
 - **CFG_BUILD_KERNEL_STACK**
 
-  Determines how to build the kernel stack. The following option is available and
-  automatically (implicitly) pre-selected:
+  Determines how to build the kernel stack. The following options are available:
 
   - __Link to Application__
 
     The openPOWERLINK kernel part will be directly linked to the user part and
     application. WinPCAP will be used as Ethernet driver.
+
+  - __Stack on PCIe__
+
+    The library `liboplkmnapp-pcieintf.lib` will be used. It contains the interface
+    to an external PCIe device interfaced through the NDIS PCIe miniport driver.
+    The kernel part of the openPOWERLINK stack is located on the external PCIe device.
+    Shared memory is used for status/control and data exchange between the user
+    and kernel layers of the openPOWERLINK stack.
 
 ## Options for embedded platforms (Non-OS) {#sect_build_demos_noos_options}
 

--- a/doc/build-drivers.md
+++ b/doc/build-drivers.md
@@ -42,6 +42,34 @@ To build the kernel driver (e.g. for a MN using the Intel 82573 network interfac
       > make
       > make install
 
+## Building a Windows NDIS PCIe miniport driver {#sect_build_drivers_build_windows_ndis_pcie}
+
+To build Windows kernel space driver, appropriate Windows Driver Kit (WDK) version
+having support for the target Windows version should be installed on your system.
+
+__NOTE__: Currently available Windows PCIe driver is supported for Windows 7 64bit
+and requires Windows Driver Kit (WDK) 8.1 for compilation.
+
+Follow the steps below to build the stack on a Windows system using MSbuild.
+Open a Visual Studio command line and enter the following commands:
+
+* Build driver for Windows 7 64bit in debug mode
+
+      > cd <openPOWERLINK_directory>\drivers\windows\drv_ndis_pcie\build
+      > cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Debug ..\
+      > msbuild /t:build /p:Platform=x64 /p:Configuration="Win7 Debug"
+
+* Build driver for Windows 7 64bit in release mode
+
+      > cd <openPOWERLINK_directory>\drivers\windows\drv_ndis_pcie\build
+      > cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ..\
+      > msbuild /t:build /p:Platform=x64 /p:Configuration="Win7 Release"
+
+`Platform` and `Configuration` parameters can be modified to compile driver for
+a different platform and Windows version.
+
+The default driver installation path is: `<openPOWERLINK_DIR>\bin\windows\<ARCH>\drv_ndis_pcie_package`
+
 ## Building a PCP daemon for Microblaze {#sect_build_drivers_build_daemon_microblaze}
 
 This section will explain the steps to build the PCP daemon for a Microblaze

--- a/doc/build-drivers.md
+++ b/doc/build-drivers.md
@@ -44,13 +44,16 @@ To build the kernel driver (e.g. for a MN using the Intel 82573 network interfac
 
 ## Building a Windows NDIS PCIe miniport driver {#sect_build_drivers_build_windows_ndis_pcie}
 
-To build Windows kernel space driver, appropriate Windows Driver Kit (WDK) version
-having support for the target Windows version should be installed on your system.
+To build the Windows NDIS PCIe miniport driver, appropriate Windows Driver Kit (WDK)
+version which supports the Windows version of the host system should be installed
+on the development system.
 
-__NOTE__: Currently available Windows PCIe driver is supported for Windows 7 64bit
-and requires Windows Driver Kit (WDK) 8.1 for compilation.
+__NOTE__: Windows PCIe driver currently provided with the openPOWERLINK, can be used
+with Windows 7 64bit and requires Windows Driver Kit (WDK) 8.1 for compilation.
+(<http://www.microsoft.com/en-us/download/details.aspx?id=42273>)
 
-Follow the steps below to build the stack on a Windows system using MSbuild.
+
+Follow the steps below to build the NDIS PCIe driver on a Windows system using MSbuild.
 Open a Visual Studio command line and enter the following commands:
 
 * Build driver for Windows 7 64bit in debug mode

--- a/doc/build-stack.md
+++ b/doc/build-stack.md
@@ -270,6 +270,16 @@ the configuration options on the command line (-DCFG_XXX=XXX) or
   Compile complete openPOWERLINK CN library. The library contains an Ethernet
   driver which is using the WinPCAP library for accessing the network. It is
   configured to contain only CN functionality.
+  
+- **CFG_COMPILE_LIB_MNAPP_PCIEINTF**
+
+  Compile openPOWERLINK MN application library which contains the interface to
+  the openPOWERLINK driver running on an external PCIe device. It is used together
+  with an NDIS PCIe miniport driver in the Windows kernel space. The NDIS PCIe
+  miniport driver is used as the communication interface between the application
+  library and the PCIe device running the openPOWERLINK kernel layer. The NDIS
+  PCIe driver uses shared memory for status/control information and data
+  exchange between application library and the PCIe device.
 
 ## Options for embedded systems (No-OS) {#sect_build_stack_options_noos}
 

--- a/doc/directories.md
+++ b/doc/directories.md
@@ -51,6 +51,7 @@ timer                         | Timer library
 trace                         | Functions for handling trace output
 dualprocshm                   | Shared memory library for dual processor systems
 sd_fat16                      | FAT16 SD card access library for Zynq SoC
+ndislib                       | NDIS library for Windows kernel space drivers
 
 ## Object dictionaries {#sect_directories_objdict}
 

--- a/doc/supported-platforms/windows.md
+++ b/doc/supported-platforms/windows.md
@@ -7,10 +7,10 @@ openPOWERLINK on Windows {#page_platform_windows}
 
 This file contains documentation for the openPOWERLINK stack on Windows.
 
-__NOTE:__ Because Windows does not provide real-time behavior, openPOWERLINK
-solutions completly running on Windows, can only be run with cycle times above 10ms.
-The achievable minimum cycle time depends very much on the used system and
-cannot be guaranteed!
+__NOTE:__ Because Windows does not provide real-time behavior, purely
+software-based openPOWERLINK solutions running on Windows, can only be
+run with cycle times above 10ms. The achievable minimum cycle time
+depends very much on the used system and cannot be guaranteed!
 
 # Requirements {#sect_windows_require}
 
@@ -145,7 +145,7 @@ Follow the steps below to build the Windows PCIe driver installer.
         > cd <openPOWERLINK_directory>\tools\windows\installer-pcie\build\installer-pcie
         > msbuild /t:build /p:Platform=x64 /p:Configuration="Release"
 
-  - Build un-installer application
+  - Build uninstaller application
 
         > cd <openPOWERLINK_directory>\tools\windows\uninstaller-pcie\build\uninstaller-pcie
         > msbuild /t:build /p:Platform=x64 /p:Configuration="Release"
@@ -153,7 +153,7 @@ Follow the steps below to build the Windows PCIe driver installer.
 * Copy the required Visual C++ Redistributable executable to `tools/windows/installer`
 directory.
 
-  Visual C++ Redistributable Package is required to run the installer and unistaller applications
+  Visual C++ Redistributable Package is required to run the installer and uninstaller applications
   on the target machine.
 
   The Visual C++ Redistributable Packages for Visual Studio 2013 can be downloaded from:

--- a/doc/supported-platforms/windows.md
+++ b/doc/supported-platforms/windows.md
@@ -7,9 +7,10 @@ openPOWERLINK on Windows {#page_platform_windows}
 
 This file contains documentation for the openPOWERLINK stack on Windows.
 
-__NOTE:__ Because Windows does not provide real-time behavior, openPOWERLINK can
-only be run with cycle times above 10ms. The achievable minimum cycle time
-depends very much on the used system and cannot be guaranteed!
+__NOTE:__ Because Windows does not provide real-time behavior, openPOWERLINK
+solutions completly running on Windows, can only be run with cycle times above 10ms.
+The achievable minimum cycle time depends very much on the used system and
+cannot be guaranteed!
 
 # Requirements {#sect_windows_require}
 
@@ -41,6 +42,7 @@ openPOWERLINK support the following build environments:
 - Microsoft Visual Studio 2005
 - Microsoft Visual Studio 2008
 - Microsoft Visual Studio 2010
+- Microsoft Visual Studio 2013
 
 ### CMake
 
@@ -61,29 +63,111 @@ be installed on the system (<http://qt.digia.com/>).
 The tool [openCONFIGURATOR](\ref page_openconfig) is needed to generate the
 network configuration for your application.
 
+### NSIS compiler
+
+NSIS (Nullsoft Scriptable Install System) (<http://nsis.sourceforge.net/Download>)
+is a professional open source system to create Windows installers.
+openPOWERLINK uses NSIS scripts to create PCIe driver installer for
+unattended driver installation on Windows.
+
 # openPOWERLINK Stack Components {#sect_windows_components}
 
 The following section contains a description of the
 [openPOWERLINK components](\ref page_components) available on a Windows system.
 
-## Stack Libraries
+## Stack Libraries {#sect_windows_components_libs}
 
 The openPOWERLINK stack is divided into a user and a kernel part. On a Windows
-system only a single process solution is available, in which the whole openPOWERLINK
-stack is linked to the application. The WinPCAP library is used to access the
-Ethernet interface.
+system the following configurations are possible:
 
-_Libraries:_
-- `stack/proj/windows/liboplkmn` (liboplkmn.lib)
-- `stack/proj/windows/liboplkcn` (liboplkcn.lib)
+- __Direct Link to Application__
 
-## Demo Applications
+  The kernel part is directly linked to the user part and application (complete
+  library) into a single executable. The stack uses the WinPCAP library for
+  accessing the Ethernet device.
+
+  _Libraries:_
+  - `stack/proj/windows/liboplkmn` (liboplkmn.lib)
+  - `stack/proj/windows/liboplkcn` (liboplkcn.lib)
+
+- __Stack on PCIe__
+
+  The application is linked to an application library which contains the interface
+  to an external PCIe device running the kernel part of the openPOWERLINK stack.
+  An NDIS PCIe miniport driver in Windows kernel space is used to communicate with
+  the PCIe device. Shared memory is used for status/control and data exchange
+  between the user and kernel layers of the openPOWERLINK stack.
+
+  _Libraries:_
+  - `stack/proj/windows/liboplkmnapp-pcieintf` (liboplkmnapp-pcieintf.lib)
+
+## Drivers {#sect_windows_components_drivers}
+
+### NDIS PCIe miniport driver
+
+The openPOWERLINK kernel layer may be executed on an external PCIe
+device which handles the time critical sections of the openPOWERLINK
+stack. This solution allows a Windows user space application to achieve
+lower cycle lengths(<250us) which is generally not possible due to
+non-realtime behaviour of Windows.
+
+An NDIS PCIe miniport driver is used to form the communication interface
+between the openPOWERLINK application library and the openPOWERLINK kernel
+stack runing on the PCIe device using shared memory for data exchange.
+
+The driver is located in: `drivers/windows/drv_ndis_pcie`
+
+## Demo Applications {#sect_windows_components_demos}
 
 The following demo application are provided on Windows:
 
 * [demo_mn_console](\ref sect_components_demo_mn_console)
 * [demo_cn_console](\ref sect_components_demo_cn_console)
 * [demo_mn_qt](\ref sect_components_demo_mn_qt)
+
+## Tools {#sect_windows_components_tools}
+
+The NSIS installer script, driver installer and uninstaller application
+projects are included as part of the stack to create an installer
+application for Windows. This script and applications helps users to
+install and configure Windows NDIS PCIe driver avoiding manual steps.
+
+The script and applications are available in directory: `tools/windows`
+
+### Building Windows PCIe driver installer
+
+Follow the steps below to build the Windows PCIe driver installer.
+
+* Open a Visual Studio command line and enter the following commands:
+
+  - Build installer application
+
+        > cd <openPOWERLINK_directory>\tools\windows\installer-pcie\build\installer-pcie
+        > msbuild /t:build /p:Platform=x64 /p:Configuration="Release"
+
+  - Build un-installer application
+
+        > cd <openPOWERLINK_directory>\tools\windows\uninstaller-pcie\build\uninstaller-pcie
+        > msbuild /t:build /p:Platform=x64 /p:Configuration="Release"
+
+* Copy the required Visual C++ Redistributable executable to `tools/windows/installer`
+directory.
+
+  Visual C++ Redistributable Package is required to run the installer and unistaller applications
+  on the target machine.
+
+  The Visual C++ Redistributable Packages for Visual Studio 2013 can be downloaded from:
+  (<https://www.microsoft.com/en-in/download/details.aspx?id=40784>)
+
+* Compile the NSIS script to generate the openPOWERLINK driver installer executable.
+
+  The script can be compiled either from the context menu option `Compile NSIS Script` or
+  using the command line utility `makensis`.
+
+      > makensis <openPOWERLINK_directory>\tools\windows\installer\openPOWERLINK_demo.nsi
+
+The default installation location for the openPOWERLINK driver installer executable is:
+`tools/windows/installer`
 
 # Running openPOWERLINK {#sect_windows_running}
 


### PR DESCRIPTION
- Update stack build steps to include application library for
  PCIe interface.
- Add build steps for NDIS PCIe miniport driver.
- Update Windows platform documentation to include PCIe
  solution details and components.