### PR TITLE
Fix for Linux kernel module loading error when using plkload

### DIFF
--- a/tools/linux/devices.txt
+++ b/tools/linux/devices.txt
@@ -4,7 +4,9 @@
 82573,Intel Corporation 82567LM,e1000e
 82573,Intel Corporation 82574L,e1000e
 8139,RTL-8139,8139too
+8139,RTL-8100/8101L/8139 PCI Fast Ethernet Adapter,8139too
 8255x,Intel Corporation 82557,e100
 8255x,Intel Corporation 8255xER,e100
+8255x,Intel Corporation PRO/100 VE Network Connection,e100
 i210,Intel Corporation I210,igb
 8111,RTL8111/8168,r8169

--- a/tools/linux/devices.txt
+++ b/tools/linux/devices.txt
@@ -4,9 +4,9 @@
 82573,Intel Corporation 82567LM,e1000e
 82573,Intel Corporation 82574L,e1000e
 8139,RTL-8139,8139too
-8139,RTL-8100/8101L/8139 PCI Fast Ethernet Adapter,8139too
+8139,RTL-8100/8101L/8139,8139too
 8255x,Intel Corporation 82557,e100
 8255x,Intel Corporation 8255xER,e100
-8255x,Intel Corporation PRO/100 VE Network Connection,e100
+8255x,Intel Corporation PRO/100,e100
 i210,Intel Corporation I210,igb
 8111,RTL8111/8168,r8169


### PR DESCRIPTION
This is fix for bug ID 2210.
Failure to load kernel module due wrong device string identifiers in devices.txt.