### PR TITLE
Fix: Disable memory caching for PCIe device memory

### DIFF
--- a/drivers/windows/drv_ndis_pcie/drvintf.c
+++ b/drivers/windows/drv_ndis_pcie/drvintf.c
@@ -1144,7 +1144,7 @@ static tOplkError mapMemory(tMemInfo* pMemInfo_p)
     // Map the memory in user space and get the address
     pMemInfo_p->pUserVa = MmMapLockedPagesSpecifyCache(pMemInfo_p->pMdl,       // MDL
                                                        UserMode,               // Mode
-                                                       MmCached,               // Caching
+                                                       MmNonCached,            // Caching
                                                        NULL,                   // Address
                                                        FALSE,                  // Bugcheck?
                                                        NormalPagePriority);    // Priority


### PR DESCRIPTION
This pull request includes changes specified in https://github.com/openPOWERLINK/openPOWERLINK_V2/pull/64