### PR TITLE
[FIX] rename DEPRECATED to OPLK_DEPRECATED

### DIFF
--- a/stack/include/oplk/oplk.h
+++ b/stack/include/oplk/oplk.h
@@ -472,8 +472,8 @@ OPLKDLLEXPORT tOplkError oplk_initialize(void);
 OPLKDLLEXPORT tOplkError oplk_create(tOplkApiInitParam* pInitParam_p);
 OPLKDLLEXPORT tOplkError oplk_destroy(void);
 OPLKDLLEXPORT void       oplk_exit(void);
-OPLKDLLEXPORT DEPRECATED tOplkError oplk_init(tOplkApiInitParam* pInitParam_p);
-OPLKDLLEXPORT DEPRECATED tOplkError oplk_shutdown(void);
+OPLKDLLEXPORT OPLK_DEPRECATED tOplkError oplk_init(tOplkApiInitParam* pInitParam_p);
+OPLKDLLEXPORT OPLK_DEPRECATED tOplkError oplk_shutdown(void);
 OPLKDLLEXPORT tOplkError oplk_execNmtCommand(tNmtEvent NmtEvent_p);
 OPLKDLLEXPORT tOplkError oplk_linkObject(UINT objIndex_p, void* pVar_p, UINT* pVarEntries_p,
                                          tObdSize* pEntrySize_p, UINT firstSubindex_p);

--- a/stack/include/oplk/targetsystem.h
+++ b/stack/include/oplk/targetsystem.h
@@ -158,7 +158,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #endif
 
-#define DEPRECATED      __attribute__((deprecated))
+#define OPLK_DEPRECATED      __attribute__((deprecated))
 
 #elif defined(_MSC_VER)
 
@@ -186,7 +186,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #define __func__        __FUNCTION__
-#define DEPRECATED      __declspec(deprecated)
+#define OPLK_DEPRECATED      __declspec(deprecated)
 
 #endif /*#elif defined (_MSC_VER) */
 


### PR DESCRIPTION
Hello,

DEPRECATED is already defined in include/linux/printk.h, so rename DEPRECATED introduced
by commit 9fe01285db96808bd7ee41db5905e6f241129bfa to OPLK_DEPRECATED.

Fixes:
openpowerlink-V2.3/drivers/linux/drv_kernelmod_edrv/../../../stack/include/oplk/targetsystem.h:161:0: warning: "DEPRECATED" redefined
 #define DEPRECATED      __attribute__((deprecated))
 ^
include/linux/printk.h:105:0: note: this is the location of the previous definition
 #define DEPRECATED "[Deprecated]: "
 ^

include/linux/printk.h:105:20: error: expected identifier or '(' before string constant
 #define DEPRECATED "[Deprecated]: "
                    ^
openpowerlink-V2.3/drivers/linux/drv_kernelmod_edrv/../../../stack/include/oplk/oplk.h:475:15: note: in expansion of macro 'DEPRECATED'
 OPLKDLLEXPORT DEPRECATED tOplkError oplk_init(tOplkApiInitParam* pInitParam_p);

Best regards,
Romain