### PR TITLE
[FIX] eventkcal-linuxkernel: use cpumask APIv2

### DIFF
--- a/stack/src/kernel/event/eventkcal-linuxkernel.c
+++ b/stack/src/kernel/event/eventkcal-linuxkernel.c
@@ -51,6 +51,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <linux/errno.h>
 #include <linux/wait.h>
 #include <linux/delay.h>
+#include <linux/sched.h>
+#include <linux/cpumask.h>
 #include <asm/uaccess.h>
 #include <asm/atomic.h>
 
@@ -164,7 +166,7 @@ tOplkError eventkcal_init(void)
 
     instance_l.threadId = kthread_run(eventThread, NULL, "EventkThread");
 
-    set_cpus_allowed(instance_l.threadId, cpumask_of_cpu(1));
+    set_cpus_allowed_ptr(instance_l.threadId, cpumask_of(1));
 
     instance_l.fInitialized = TRUE;
 


### PR DESCRIPTION
Hello,

Use cpumask_of() instead of cpumask_of_cpu() which is deprecated
since 2.6.32. Due to this modification, use set_cpus_allowed_ptr()
instead of set_cpus_allowed().

cpumask_of() is available since 2.6.28.

Also add sched.h and cpumask.h include.

Best regards,
Romain