### PR TITLE
Fix for initialization failure in PCIe designs

### DIFF
--- a/drivers/windows/drv_ndis_pcie/drvintf.c
+++ b/drivers/windows/drv_ndis_pcie/drvintf.c
@@ -711,7 +711,7 @@ tOplkError drv_mapKernelMem(UINT8** ppKernelMem_p, UINT8** ppUserMem_p, UINT32* 
     tMemInfo*               pKernel2UserMemInfo = &drvInstance_l.kernel2UserMem;
     tDualprocSharedMemInst  sharedMemInst;
 
-    if (*ppKernelMem_p == NULL || *ppUserMem_p == NULL)
+    if (ppKernelMem_p == NULL || ppUserMem_p == NULL)
         return kErrorNoResource;
 
     dualRet = dualprocshm_getSharedMemInfo(drvInstance_l.pDualProcDrvInst,

--- a/stack/src/common/memmap/memmap-winioctl.c
+++ b/stack/src/common/memmap/memmap-winioctl.c
@@ -123,6 +123,8 @@ tMemMapReturn memmap_init(void)
     tMemStruc   inMemStruc;
     tMemStruc*  pOutMemStruc = &memMapInstance_l.memStruc;
 
+    OPLK_MEMSET(&inMemStruc, 0, sizeof(inMemStruc));
+
     memMapInstance_l.hFileHandle = ctrlucal_getFd();
 
     if (memMapInstance_l.hFileHandle == NULL)

--- a/stack/src/user/ctrl/ctrlucal-winioctl.c
+++ b/stack/src/user/ctrl/ctrlucal-winioctl.c
@@ -130,6 +130,8 @@ tOplkError ctrlucal_init(void)
         return kErrorNoResource;
     }
 
+    OPLK_MEMSET(&inMemStruc, 0, sizeof(inMemStruc));
+
     if (!DeviceIoControl(hFileHandle_l, PLK_CMD_MAP_MEM,
         &inMemStruc, sizeof(tMemStruc), pOutMemStruc, sizeof(tMemStruc),
         &bytesReturned, NULL))


### PR DESCRIPTION
Due to wrong NULL pointer checks in NDIS PCIe driver,
the initialization of memory mapping module for
PCIe solution fails.

This commit revises the NULL pointer checks in driver and
adds memset routines to avoid garbage values for the pointer
variables used for memory mapping.