### PR TITLE
Fix LED blink errors

### DIFF
--- a/stack/include/common/led.h
+++ b/stack/include/common/led.h
@@ -63,9 +63,9 @@ typedef enum
     kLedModeOn             = 0x02,  ///< LED on.
     kLedModeFlickering     = 0x03,  ///< LED on for 50ms and off for 50ms.
     kLedModeBlinking       = 0x04,  ///< LED on for 200ms and off for 200ms.
-    kLedModeSingleFlash    = 0x05,  ///< LED on for 200ms and then it switch off.
-    kLedModeDoubleFlash    = 0x06,  ///< LED on for 200ms and off for 1000ms, repeat twice.
-    kLedModeTripleFlash    = 0x07,  ///< LED on for 200ms and off for 1000ms, repeat thrice.
+    kLedModeSingleFlash    = 0x05,  ///< LED on for 200ms and then off for 1000ms.
+    kLedModeDoubleFlash    = 0x06,  ///< Blink twice and then off for 1000ms.
+    kLedModeTripleFlash    = 0x07,  ///< Blink thrice and then off for 1000ms.
 } eLedMode;
 
 /**

--- a/stack/include/kernel/ledk.h
+++ b/stack/include/kernel/ledk.h
@@ -72,6 +72,8 @@ tOplkError ledk_handleNmtStateChange(tEventNmtStateChange nmtStateChange_p);
 tOplkError ledk_process(void);
 
 //ledktimer functions
+tOplkError ledk_timerInit(void);
+tOplkError ledk_timerExit(void);
 tOplkError ledk_updateLedState(void);
 tOplkError ledk_setLedMode(tLedType ledType_p, tLedMode newMode_p);
 

--- a/stack/src/kernel/led/ledk.c
+++ b/stack/src/kernel/led/ledk.c
@@ -99,7 +99,7 @@ The function initializes the kernel LED module.
 //------------------------------------------------------------------------------
 tOplkError ledk_init(void)
 {
-    return kErrorOk;
+    return ledk_timerInit();
 }
 
 //------------------------------------------------------------------------------
@@ -115,7 +115,7 @@ The function cleans up the kernel LED module.
 //------------------------------------------------------------------------------
 tOplkError ledk_exit(void)
 {
-    return kErrorOk;
+    return ledk_timerExit();
 }
 
 //------------------------------------------------------------------------------

--- a/stack/src/kernel/led/ledktimer.c
+++ b/stack/src/kernel/led/ledktimer.c
@@ -101,6 +101,39 @@ static tLedkInstance   ledkInstance_l;
 
 //------------------------------------------------------------------------------
 /**
+\brief  Initialize kernel LED timer module
+
+The function initializes the kernel LED timer module.
+
+\return The function returns a tOplkError error code.
+
+\ingroup module_ledk
+*/
+//------------------------------------------------------------------------------
+tOplkError ledk_timerInit(void)
+{
+    OPLK_MEMSET(&ledkInstance_l, 0, sizeof(tLedkInstance));
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Cleanup kernel LED timer module
+
+The function cleans up the kernel LED timer module.
+
+\return The function returns a tOplkError error code.
+
+\ingroup module_ledk
+*/
+//------------------------------------------------------------------------------
+tOplkError ledk_timerExit(void)
+{
+    return kErrorOk;
+}
+
+//------------------------------------------------------------------------------
+/**
 \brief  Update Led State
 
 This function updates the status LED state. The blinking is achieved by using the system timer ticks
@@ -113,11 +146,13 @@ This function updates the status LED state. The blinking is achieved by using th
 tOplkError ledk_updateLedState(void)
 {
     UINT                timeout = 0;
+    UINT32              tickCount = 0;
     BOOL                fLedOn = FALSE;
     tOplkError          ret = kErrorOk;
 
     // Setting the new timeout value
-    timeout = target_getTickCount() - ledkInstance_l.startTimeInMs;
+    tickCount = target_getTickCount();
+    timeout = tickCount - ledkInstance_l.startTimeInMs;
 
     if (timeout >= ledkInstance_l.timeoutInMs && timeout > 0)
     {
@@ -210,7 +245,7 @@ tOplkError ledk_updateLedState(void)
         }
 
         ledkInstance_l.timeoutInMs = timeout;
-        ledkInstance_l.startTimeInMs += ledkInstance_l.timeoutInMs;
+        ledkInstance_l.startTimeInMs = tickCount;
         ret = target_setLed(kLedTypeStatus, fLedOn);
     }
 


### PR DESCRIPTION
The external blink periods observed for the LEDs were
not similar to the specified periods in the state machine.

Modify the ledktimer implementation as following to fix the issue:

 - Add initialization routine to reset the local instance.
 - Use the current tickCount as the start time for the next
   timeout calculation.
