### PR TITLE
[Fix] Reduce timeout steps in ctrlucal_executeCmd

### DIFF
--- a/stack/src/user/ctrl/ctrlucal-hostif.c
+++ b/stack/src/user/ctrl/ctrlucal-hostif.c
@@ -237,9 +237,9 @@ tOplkError ctrlucal_executeCmd(tCtrlCmdType cmd_p, UINT16* pRetVal_p)
     hostif_setCommand(instance_l.hifInstance, hifcmd);
 
     /* wait for response */
-    for (timeout = 0; timeout < CMD_TIMEOUT_SEC; timeout++)
+    for (timeout = 0; timeout < CMD_TIMEOUT_SEC*100; timeout++)
     {
-        target_msleep(1000U);
+        target_msleep(10U);
 
         hifret = hostif_getCommand(instance_l.hifInstance, &hifcmd);
         if (hifret != kHostifSuccessful)


### PR DESCRIPTION
In the case of an hostinterface CAL, the function ctrlucal_executeCmd()
posts a command, then checks periodically for a result before possibly
exiting because of a timeout.

This patch reduces the granularity of those checks from 1 second to 10
milliseconds. Since the functions starts by waiting one period, and is
called several times during the initialization, this patch saves around
5 seconds of boot time in the case of dual-core hostinterface designs.

This may not be the best way to do it, but I think this behavior should
be corrected one way or another! I ran several tests on the DE2-115
and didn't see any particular problem.

Best regards,
Sylvain