### PR TITLE
Fix for Zynq run failure

### DIFF
--- a/stack/proj/generic/liboplkmndrv-dualprocshm/oplkcfg.h
+++ b/stack/proj/generic/liboplkmndrv-dualprocshm/oplkcfg.h
@@ -63,9 +63,9 @@ The generic defines are valid for the whole openPOWERLINK stack.
 #define CONFIG_INCLUDE_LEDK
 #define CONFIG_INCLUDE_SDO_ASND
 
-// TODO: PCIe interface does not support virtual Ethernet
-//       Add it through conditional compilation
-//#define CONFIG_INCLUDE_VETH
+#ifndef CONFIG_PCIE
+#define CONFIG_INCLUDE_VETH
+#endif
 
 #ifndef BENCHMARK_MODULES
 #define BENCHMARK_MODULES                   (0 |\


### PR DESCRIPTION
The PCIe design does not support VEth interface currently.
Due to this the openPOWERLINK kernel library for dualprocshm
interface should be compiled without the VEth.

As a workaround the VEth module was removed from the kernel
configuration, which caused feature mismatch on Zynq and
Altera SoC design.

The commit adds conditional compilation using a platform specific
compiler flag to identify PCIe design and disable the VEth
only for PCIe designs.