### PR TITLE
Avoid failure of embedded MN demo on platforms with no VEth support

### DIFF
--- a/apps/demo_cn_embedded/src/main.c
+++ b/apps/demo_cn_embedded/src/main.c
@@ -165,7 +165,10 @@ int main(void)
         goto Exit;
 
     if ((ret = oplk_setNonPlkForward(TRUE)) != kErrorOk)
-        goto Exit;
+    {
+        PRINTF("WARNING: oplk_setNonPlkForward() failed with \"%s\"\n(Error:0x%x!)\n",
+                debugstr_getRetValStr(ret), ret);
+    }
 
     loopMain(&instance_l);
 

--- a/apps/demo_mn_embedded/src/main.c
+++ b/apps/demo_mn_embedded/src/main.c
@@ -198,7 +198,8 @@ int main(void)
 
     if ((ret = oplk_setNonPlkForward(TRUE)) != kErrorOk)
     {
-        PRINTF("WARNING:oplk_setNonPlkForward() failed with error (0x%X)\n", ret);
+        PRINTF("WARNING: oplk_setNonPlkForward() failed with \"%s\"\n(Error:0x%x!)\n",
+               debugstr_getRetValStr(ret), ret);
     }
 
     loopMain(&instance_l);

--- a/apps/demo_mn_embedded/src/main.c
+++ b/apps/demo_mn_embedded/src/main.c
@@ -197,7 +197,9 @@ int main(void)
         goto Exit;
 
     if ((ret = oplk_setNonPlkForward(TRUE)) != kErrorOk)
-        goto Exit;
+    {
+        PRINTF("WARNING:oplk_setNonPlkForward() failed with error (0x%X)\n", ret);
+    }
 
     loopMain(&instance_l);
 


### PR DESCRIPTION
The embedded MN demo fails on platforms which do not support
virtual Ethernet interface.

As virtual Ethernet is not a mandatory requirement, this fix
updates the embedded demo to avoid stack shutdown on such
platforms and displays a warning message instead on failure
to register the virtual Ethernet callback.
