### PR TITLE
Fix for application crash issue identified on APC2100

### DIFF
--- a/stack/src/user/ctrl/ctrlu.c
+++ b/stack/src/user/ctrl/ctrlu.c
@@ -514,6 +514,9 @@ tOplkError ctrlu_shutdownStack(void)
     DEBUG_LVL_CTRL_TRACE("pdou_exit():    0x%X\n", ret);
 #endif
 
+    ret = eventu_exit();
+    DEBUG_LVL_CTRL_TRACE("eventu_exit():  0x%X\n", ret);
+
     ret = dllucal_exit();
     DEBUG_LVL_CTRL_TRACE("dllucal_exit(): 0x%X\n", ret);
 
@@ -522,9 +525,6 @@ tOplkError ctrlu_shutdownStack(void)
 
     ret = timeru_exit();
     DEBUG_LVL_CTRL_TRACE("timeru_exit():  0x%X\n", ret);
-
-    ret = eventu_exit();
-    DEBUG_LVL_CTRL_TRACE("eventu_exit():  0x%X\n", ret);
 
     /* shutdown kernel stack */
     ret = ctrlucal_executeCmd(kCtrlCleanupStack, &retVal);


### PR DESCRIPTION
This pull request contains the fix for application crash issue identified on APC2100 with Windows PCIe solution.

Fix was tested on:
 - Zynq ZC702 MN design
 - Terasic DE2-115 dual processor MN design
 - Linux kernel module design
 - Linux user space design
 - APC2100 Windows PCIe MN design 