### PR TITLE
Add troubleshooting information for CRC error on Altera C5 SoC

### DIFF
--- a/doc/supported-platforms/altera-soc.md
+++ b/doc/supported-platforms/altera-soc.md
@@ -140,3 +140,14 @@ Requirement: Steps in the section *How to build the binary* are completed.
 5. Browse to `<openPOWERLINK_directory>` (via the button *Browse...*)
 6. Select the `demo_mn_embedded` project.
 7. Press the button *Finish*.
+
+# Troubleshooting {#sect_altera-soc_trouble}
+
+- Frame CRC error for the transmitted frames from PHY
+
+  The PHYs of Altera Cyclone V SoC revision D development board are configured to
+  operate in synchronous mode, by boot strapping resistors. For POWERLINK operation,
+  the PHYs need to be configured in asynchronous mode.
+
+  To enable asynchronous operation the boot strapping resistor `R522` needs to be removed.
+  For more information refer to [Rocket boards website](http://rocketboards.org/foswiki/view/Documentation/CVSoCDevelopmentBoardRevisionInfo)


### PR DESCRIPTION
Update Altera C5 SoC platform documentation to include
troubleshooting for transmitted Ethernet frame CRC error issue
on Revision D development board.

Note: The troubleshooting steps are not yet tested on the boards as they require changes on the board.