### PR TITLE
Edrv i210 implementation to support CN in MN driver

### DIFF
--- a/stack/include/kernel/edrv.h
+++ b/stack/include/kernel/edrv.h
@@ -157,7 +157,7 @@ struct sEdrvTxBuffer
     union
     {
         UINT32          ticks;              ///< Launch time of the frame in ticks
-        UINT64          nanoSeconds;        ///< Launch time of the frame in nano seconds
+        UINT64          nanoseconds;        ///< Launch time of the frame in nano seconds
     } launchTime;
 
     tEdrvTxHandler      pfnTxHandler;       ///< Tx callback function

--- a/stack/include/kernel/edrv.h
+++ b/stack/include/kernel/edrv.h
@@ -154,7 +154,13 @@ struct sEdrvTxBuffer
     UINT                txFrameSize;    ///< Size of Tx frame (without CRC)
     UINT32              timeOffsetNs;   ///< Tx delay to a previously sent frame [ns]
     UINT32              timeOffsetAbs;  ///< Absolute Tx time [ticks]
-    UINT64              launchTime;     ///< Launch time of frame [ns]
+    BOOL                fTimeTrig;      ///< Flag to send the frame using time triggered
+    union
+    {
+        UINT32              timeOffsetAbs;  ///< Absolute Tx time [ticks]
+        UINT64              launchTime;     ///< Launch time of frame [ns]
+    } tttx;
+
     tEdrvTxHandler      pfnTxHandler;   ///< Tx callback function
     tEdrvTxBufferNumber txBufferNumber; ///< Edrv Tx buffer number
     UINT8*              pBuffer;        ///< Pointer to the Tx buffer

--- a/stack/include/kernel/edrv.h
+++ b/stack/include/kernel/edrv.h
@@ -151,20 +151,19 @@ This structure is the Tx buffer descriptor.
 */
 struct sEdrvTxBuffer
 {
-    UINT                txFrameSize;    ///< Size of Tx frame (without CRC)
-    UINT32              timeOffsetNs;   ///< Tx delay to a previously sent frame [ns]
-    UINT32              timeOffsetAbs;  ///< Absolute Tx time [ticks]
-    BOOL                fTimeTrig;      ///< Flag to send the frame using time triggered
+    UINT                txFrameSize;        ///< Size of Tx frame (without CRC)
+    UINT32              timeOffsetNs;       ///< Tx delay to a previously sent frame [ns]
+    BOOL                fLaunchTimeValid;   ///< Flag to identify a valid launch time
     union
     {
-        UINT32              timeOffsetAbs;  ///< Absolute Tx time [ticks]
-        UINT64              launchTime;     ///< Launch time of frame [ns]
-    } tttx;
+        UINT32          ticks;              ///< Launch time of the frame in ticks
+        UINT64          nanoSeconds;        ///< Launch time of the frame in nano seconds
+    } launchTime;
 
-    tEdrvTxHandler      pfnTxHandler;   ///< Tx callback function
-    tEdrvTxBufferNumber txBufferNumber; ///< Edrv Tx buffer number
-    UINT8*              pBuffer;        ///< Pointer to the Tx buffer
-    UINT                maxBufferSize;  ///< Maximum size of the Tx buffer
+    tEdrvTxHandler      pfnTxHandler;       ///< Tx callback function
+    tEdrvTxBufferNumber txBufferNumber;     ///< Edrv Tx buffer number
+    UINT8*              pBuffer;            ///< Pointer to the Tx buffer
+    UINT                maxBufferSize;      ///< Maximum size of the Tx buffer
 };
 
 /**

--- a/stack/src/kernel/edrv/edrv-i210.c
+++ b/stack/src/kernel/edrv/edrv-i210.c
@@ -996,7 +996,7 @@ tOplkError edrv_sendTxBuffer(tEdrvTxBuffer* pBuffer_p)
     }
 
 #if EDRV_USE_TTTX != FALSE
-    if (pBuffer_p->fTimeTrig)
+    if (pBuffer_p->fLaunchTimeValid)
     {
         // Send packet using time triggered send
         tEdrvTtxDesc*   pTtxDesc;
@@ -1016,22 +1016,22 @@ tOplkError edrv_sendTxBuffer(tEdrvTxBuffer* pBuffer_p)
 
         pTtxDesc->ctxtDesc.idxL4lenMss = 0;
         pTtxDesc->ctxtDesc.ipMaclenVlan = 0;
-        launchTime = pBuffer_p->tttx.launchTime;
+        launchTime = pBuffer_p->launchTime.nanoSeconds;
 
         if (launchTime == 0)
         {
             getMacTime(&launchTime);
-            pBuffer_p->tttx.launchTime = launchTime;
+            pBuffer_p->launchTime.nanoSeconds = launchTime;
         }
         // Scale the launch time to 32 nsecs unit
         do_div(launchTime, SEC_TO_NSEC);
-        curTime = pBuffer_p->tttx.launchTime - (launchTime * SEC_TO_NSEC);
+        curTime = pBuffer_p->launchTime.nanoSeconds - (launchTime * SEC_TO_NSEC);
         do_div(curTime, 32);
 
         pTtxDesc->ctxtDesc.launchTime = curTime;
 
         // Always reset the launch time
-        pBuffer_p->tttx.launchTime = 0;
+        pBuffer_p->launchTime.nanoSeconds = 0;
 
         // Set descriptor type
         pTtxDesc->ctxtDesc.tucmdType = (EDRV_TDESC_CMD_DEXT | EDRV_TDESC_DTYP_CTXT);

--- a/stack/src/kernel/edrv/edrv-i210.c
+++ b/stack/src/kernel/edrv/edrv-i210.c
@@ -2382,17 +2382,17 @@ static tOplkError sendTimeTrigBuffer(tEdrvTxBuffer* pBuffer_p)
 
     pTtxDesc->ctxtDesc.idxL4lenMss = 0;
     pTtxDesc->ctxtDesc.ipMaclenVlan = 0;
-    launchTime = pBuffer_p->launchTime.nanoSeconds;
+    launchTime = pBuffer_p->launchTime.nanoseconds;
 
     // Scale the launch time to 32 nsecs unit
     do_div(launchTime, SEC_TO_NSEC);
-    curTime = pBuffer_p->launchTime.nanoSeconds - (launchTime * SEC_TO_NSEC);
+    curTime = pBuffer_p->launchTime.nanoseconds - (launchTime * SEC_TO_NSEC);
     do_div(curTime, 32);
 
     pTtxDesc->ctxtDesc.launchTime = curTime;
 
     // Always reset the launch time
-    pBuffer_p->launchTime.nanoSeconds = 0;
+    pBuffer_p->launchTime.nanoseconds = 0;
 
     // Set descriptor type
     pTtxDesc->ctxtDesc.tucmdType = (EDRV_TDESC_CMD_DEXT | EDRV_TDESC_DTYP_CTXT);

--- a/stack/src/kernel/edrv/edrv-i210.c
+++ b/stack/src/kernel/edrv/edrv-i210.c
@@ -612,13 +612,12 @@ static void freeRxBuffers(void);
 static tOplkError initRxQueue(tEdrvQueue* pRxQueue_p);
 static tOplkError allocateRxBuffer(tEdrvQueue* pRxQueue_p);
 static void configureRxQueue(tEdrvQueue* pRxQueue_p);
-#if EDRV_USE_TTTX != FALSE
 static void initQavMode(void);
-#endif
 static void writeIvarRegister(INT vector_p, INT index_p, INT offset_p);
 static INT requestMsixIrq(void);
 static INT initOnePciDev(struct pci_dev* pPciDev_p, const struct pci_device_id* pId_p);
 static void removeOnePciDev(struct pci_dev* pPciDev_p);
+static tOplkError getMacTime(UINT64* pCurtime_p);
 
 //---------------------------------------------------------------------------
 // module global vars
@@ -986,11 +985,8 @@ tOplkError edrv_sendTxBuffer(tEdrvTxBuffer* pBuffer_p)
     INT             index = 0;
     dma_addr_t      txDma;
     tEdrvTtxDesc*   pTtxDesc;
-
-#if EDRV_USE_TTTX != FALSE
     UINT64          launchTime;
     UINT64          curTime;
-#endif
 
     bufferNumber = pBuffer_p->txBufferNumber.value;
 
@@ -1014,17 +1010,23 @@ tOplkError edrv_sendTxBuffer(tEdrvTxBuffer* pBuffer_p)
     pTtxDesc->ctxtDesc.idxL4lenMss = 0;
     pTtxDesc->ctxtDesc.ipMaclenVlan = 0;
 
-#if EDRV_USE_TTTX != FALSE
-    launchTime = pBuffer_p->launchTime;
+    launchTime = pBuffer_p->tttx.launchTime;
+
+    if (!pBuffer_p->fTimeTrig)
+    {
+        getMacTime(&launchTime);
+        pBuffer_p->tttx.launchTime = launchTime;
+    }
 
     // Scale the launch time to 32 nsecs unit
     do_div(launchTime, SEC_TO_NSEC);
-    curTime = pBuffer_p->launchTime - (launchTime * SEC_TO_NSEC);
+    curTime = pBuffer_p->tttx.launchTime - (launchTime * SEC_TO_NSEC);
     do_div(curTime, 32);
+
     pTtxDesc->ctxtDesc.launchTime = curTime;
-#else
-    pTtxDesc->ctxtDesc.launchTime = 0;
-#endif
+
+    // Always reset the launch time
+    pBuffer_p->tttx.launchTime = 0;
 
     // Set descriptor type
     pTtxDesc->ctxtDesc.tucmdType = (EDRV_TDESC_CMD_DEXT | EDRV_TDESC_DTYP_CTXT);
@@ -1100,24 +1102,16 @@ The function retrieves the current MAC time.
 //------------------------------------------------------------------------------
 tOplkError edrv_getMacTime(UINT64* pCurtime_p)
 {
-    UINT32      timh;
-    UINT32      timl;
-    UINT32      reg;
+    UINT64      curtime;
+    tOplkError  ret;
 
-    if (pCurtime_p == NULL)
-        return kErrorNoResource;
+    ret = getMacTime(&curtime);
+    if (ret != kErrorOk)
+        return ret;
 
-    // Sample the current SYSTIM time in Auxiliary registers
-    reg = EDRV_REGDW_READ(EDRV_TSAUXC);
-    reg |= EDRV_TSAUXC_SAMP_AUTO;
-    EDRV_REGDW_WRITE(EDRV_TSAUXC, reg);
+    *pCurtime_p = curtime;
 
-    timl = EDRV_REGDW_READ(EDRV_AUXSTMPL0);
-    timh = EDRV_REGDW_READ(EDRV_AUXSTMPH0);
-
-    *pCurtime_p = (UINT64)timh * SEC_TO_NSEC + (UINT64)timl;
-
-    return kErrorOk;
+    return ret;
 }
 
 //------------------------------------------------------------------------------
@@ -1500,6 +1494,39 @@ static irqreturn_t edrvIrqHandler(INT irqNum_p, void* ppDevInstData_p)
 
 Exit:
     return handled;
+}
+
+//------------------------------------------------------------------------------
+/**
+\brief  Retrieve current MAC time
+
+The function retrieves the current MAC time.
+
+\param  pCurtime_p    Pointer to store the current MAC time.
+
+\return The function returns a tOplkError error code.
+*/
+//------------------------------------------------------------------------------
+static tOplkError getMacTime(UINT64* pCurtime_p)
+{
+    UINT32      timh;
+    UINT32      timl;
+    UINT32      reg;
+
+    if (pCurtime_p == NULL)
+        return kErrorNoResource;
+
+    // Sample the current SYSTIM time in Auxiliary registers
+    reg = EDRV_REGDW_READ(EDRV_TSAUXC);
+    reg |= EDRV_TSAUXC_SAMP_AUTO;
+    EDRV_REGDW_WRITE(EDRV_TSAUXC, reg);
+
+    timl = EDRV_REGDW_READ(EDRV_AUXSTMPL0);
+    timh = EDRV_REGDW_READ(EDRV_AUXSTMPH0);
+
+    *pCurtime_p = (UINT64)timh * SEC_TO_NSEC + (UINT64)timl;
+
+    return kErrorOk;
 }
 
 //------------------------------------------------------------------------------
@@ -2157,7 +2184,6 @@ static void configureRxQueue(tEdrvQueue* pRxQueue_p)
         printk("....Done\n");
 }
 
-#if EDRV_USE_TTTX != FALSE
 //------------------------------------------------------------------------------
 /**
 \brief  Initialize Qav mode
@@ -2199,7 +2225,6 @@ static void initQavMode(void)
     EDRV_REGDW_WRITE(EDRV_LAUNCH_OSO, dwLaunchOff);
 
 }
-#endif
 
 //------------------------------------------------------------------------------
 /**
@@ -2613,10 +2638,8 @@ static INT initOnePciDev(struct pci_dev* pPciDev_p, const struct pci_device_id* 
         }
     }
 
-#if EDRV_USE_TTTX != FALSE
     // Configure device for Qav mode
     initQavMode();
-#endif
 
     // DMA configuration
     EDRV_REGDW_WRITE(EDRV_DTX_MAX_PKTSZ_REG, EDRV_MAX_FRAME_SIZE/64);
@@ -2868,4 +2891,4 @@ Exit:
     return;
 }
 
-///\}
+/// \}

--- a/stack/src/kernel/edrv/edrv-openmac.c
+++ b/stack/src/kernel/edrv/edrv-openmac.c
@@ -594,11 +594,11 @@ tOplkError edrv_sendTxBuffer(tEdrvTxBuffer* pBuffer_p)
 
     pPacket->length = pBuffer_p->txFrameSize;
 #if CONFIG_EDRV_TIME_TRIG_TX != FALSE
-    if (pBuffer_p->fTimeTrig)
+    if (pBuffer_p->fLaunchTimeValid)
     {
         //free tx descriptors available
         txLength = omethTransmitTime(edrvInstance_l.pMacInst, pPacket,
-                        txAckCb, pBuffer_p, pBuffer_p->tttx.timeOffsetAbs);
+                        txAckCb, pBuffer_p, pBuffer_p->launchTime.ticks);
 
         if (txLength == 0)
         {
@@ -614,7 +614,7 @@ tOplkError edrv_sendTxBuffer(tEdrvTxBuffer* pBuffer_p)
             {
                 tEdrv2ndTxQueue* pTxqueue = &edrvInstance_l.txQueue[edrvInstance_l.txQueueWriteIndex & (CONFIG_EDRV_MAX_TX2_BUFFERS-1)];
                 pTxqueue->pBuffer = pBuffer_p;
-                pTxqueue->timeOffsetAbs = pBuffer_p->tttx.timeOffsetAbs;
+                pTxqueue->timeOffsetAbs = pBuffer_p->launchTime.ticks;
 
                 edrvInstance_l.txQueueWriteIndex++;
                 ret = kErrorOk;

--- a/stack/src/kernel/edrv/edrv-openmac.c
+++ b/stack/src/kernel/edrv/edrv-openmac.c
@@ -594,11 +594,11 @@ tOplkError edrv_sendTxBuffer(tEdrvTxBuffer* pBuffer_p)
 
     pPacket->length = pBuffer_p->txFrameSize;
 #if CONFIG_EDRV_TIME_TRIG_TX != FALSE
-    if ((pBuffer_p->timeOffsetAbs & 1) == 1)
+    if (pBuffer_p->fTimeTrig)
     {
         //free tx descriptors available
         txLength = omethTransmitTime(edrvInstance_l.pMacInst, pPacket,
-                        txAckCb, pBuffer_p, pBuffer_p->timeOffsetAbs);
+                        txAckCb, pBuffer_p, pBuffer_p->tttx.timeOffsetAbs);
 
         if (txLength == 0)
         {
@@ -614,7 +614,7 @@ tOplkError edrv_sendTxBuffer(tEdrvTxBuffer* pBuffer_p)
             {
                 tEdrv2ndTxQueue* pTxqueue = &edrvInstance_l.txQueue[edrvInstance_l.txQueueWriteIndex & (CONFIG_EDRV_MAX_TX2_BUFFERS-1)];
                 pTxqueue->pBuffer = pBuffer_p;
-                pTxqueue->timeOffsetAbs = pBuffer_p->timeOffsetAbs;
+                pTxqueue->timeOffsetAbs = pBuffer_p->tttx.timeOffsetAbs;
 
                 edrvInstance_l.txQueueWriteIndex++;
                 ret = kErrorOk;
@@ -1445,4 +1445,4 @@ static INT rxHook(void* pArg_p, ometh_packet_typ* pPacket_p, OMETH_BUF_FREE_FCT*
     return ret;
 }
 
-///\}
+/// \}

--- a/stack/src/kernel/edrv/edrvcyclic-openmac.c
+++ b/stack/src/kernel/edrv/edrvcyclic-openmac.c
@@ -537,8 +537,10 @@ static tOplkError processTxBufferList(void)
             absoluteTime += OMETH_NS_2_TICKS(pTxBuffer->timeOffsetNs);
         }
 
-        // Set the absolute Tx start time, and OR the lowest bit to give Edrv a hint
-        pTxBuffer->timeOffsetAbs = absoluteTime | 1; // Lowest bit enables time triggered send
+        // set the absolute Tx start time, and the fTimeTrig = TRUE, to
+        // use time triggered send
+        pTxBuffer->tttx.timeOffsetAbs = absoluteTime;
+        pTxBuffer->fTimeTrig = TRUE; // Enables time triggered send
 
         ret = edrv_sendTxBuffer(pTxBuffer);
         if (ret != kErrorOk)
@@ -546,9 +548,10 @@ static tOplkError processTxBufferList(void)
             goto Exit;
         }
 
-        // Set the absolute Tx start time to zero
-        // -> If the Tx buffer is reused as manual Tx, edrv_sendTxBuffer is not confused!
-        pTxBuffer->timeOffsetAbs = 0;
+        // set fTimeTrig flag to FALSE
+        // -> If the Tx buffer is reused as manual Tx, edrv_sendTxBuffer will send it normally!
+        pTxBuffer->tttx.timeOffsetAbs = 0;
+        pTxBuffer->fTimeTrig = FALSE;
 
         nextOffsetNs = (EDRVCYC_PREAMB_SIZE + EDRV_ETH_CRC_SIZE) * EDRVCYC_BYTETIME_NS;
 

--- a/stack/src/kernel/edrv/edrvcyclic-openmac.c
+++ b/stack/src/kernel/edrv/edrvcyclic-openmac.c
@@ -537,10 +537,10 @@ static tOplkError processTxBufferList(void)
             absoluteTime += OMETH_NS_2_TICKS(pTxBuffer->timeOffsetNs);
         }
 
-        // set the absolute Tx start time, and the fTimeTrig = TRUE, to
+        // set the absolute Tx start time, and the fLaunchTimeValid = TRUE, to
         // use time triggered send
-        pTxBuffer->tttx.timeOffsetAbs = absoluteTime;
-        pTxBuffer->fTimeTrig = TRUE; // Enables time triggered send
+        pTxBuffer->launchTime.ticks = absoluteTime;
+        pTxBuffer->fLaunchTimeValid = TRUE; // Enables time triggered send
 
         ret = edrv_sendTxBuffer(pTxBuffer);
         if (ret != kErrorOk)
@@ -548,10 +548,9 @@ static tOplkError processTxBufferList(void)
             goto Exit;
         }
 
-        // set fTimeTrig flag to FALSE
+        // set fLaunchTimeValid flag to FALSE
         // -> If the Tx buffer is reused as manual Tx, edrv_sendTxBuffer will send it normally!
-        pTxBuffer->tttx.timeOffsetAbs = 0;
-        pTxBuffer->fTimeTrig = FALSE;
+        pTxBuffer->fLaunchTimeValid = FALSE;
 
         nextOffsetNs = (EDRVCYC_PREAMB_SIZE + EDRV_ETH_CRC_SIZE) * EDRVCYC_BYTETIME_NS;
 

--- a/stack/src/kernel/edrv/edrvcyclic.c
+++ b/stack/src/kernel/edrv/edrvcyclic.c
@@ -703,18 +703,18 @@ static tOplkError processTxBufferList(BOOL fCallSyncCb_p)
 
         if (fFirstPacket)
         {
-            pTxBuffer->launchTime.nanoSeconds = launchTime;
+            pTxBuffer->launchTime.nanoseconds = launchTime;
             pTxBuffer->fLaunchTimeValid = TRUE;
             fFirstPacket = FALSE;
         }
         else
         {
             launchTime = launchTime + (UINT64)pTxBuffer->timeOffsetNs;
-            pTxBuffer->launchTime.nanoSeconds = launchTime;
+            pTxBuffer->launchTime.nanoseconds = launchTime;
             pTxBuffer->fLaunchTimeValid = TRUE;
         }
 
-        if ((pTxBuffer->launchTime.nanoSeconds - cycleMin) > (cycleMax - cycleMin))
+        if ((pTxBuffer->launchTime.nanoseconds - cycleMin) > (cycleMax - cycleMin))
         {
             ret = kErrorEdrvTxListNotFinishedYet;
             goto Exit;
@@ -724,7 +724,7 @@ static tOplkError processTxBufferList(BOOL fCallSyncCb_p)
         if (ret != kErrorOk)
             goto Exit;
 
-        pTxBuffer->launchTime.nanoSeconds = 0;
+        pTxBuffer->launchTime.nanoseconds = 0;
         pTxBuffer->fLaunchTimeValid = FALSE;
 
         edrvcyclicInstance_l.curTxBufferEntry++;

--- a/stack/src/kernel/edrv/edrvcyclic.c
+++ b/stack/src/kernel/edrv/edrvcyclic.c
@@ -703,16 +703,18 @@ static tOplkError processTxBufferList(BOOL fCallSyncCb_p)
 
         if (fFirstPacket)
         {
-            pTxBuffer->launchTime = launchTime;
+            pTxBuffer->tttx.launchTime = launchTime;
+            pTxBuffer->fTimeTrig = TRUE;
             fFirstPacket = FALSE;
         }
         else
         {
             launchTime = launchTime + (UINT64)pTxBuffer->timeOffsetNs;
-            pTxBuffer->launchTime = launchTime;
+            pTxBuffer->tttx.launchTime = launchTime;
+            pTxBuffer->fTimeTrig = TRUE;
         }
 
-        if ((pTxBuffer->launchTime - cycleMin) > (cycleMax - cycleMin))
+        if ((pTxBuffer->tttx.launchTime - cycleMin) > (cycleMax - cycleMin))
         {
             ret = kErrorEdrvTxListNotFinishedYet;
             goto Exit;
@@ -722,7 +724,9 @@ static tOplkError processTxBufferList(BOOL fCallSyncCb_p)
         if (ret != kErrorOk)
             goto Exit;
 
-        pTxBuffer->launchTime = 0;
+        pTxBuffer->tttx.launchTime = 0;
+        pTxBuffer->fTimeTrig = FALSE;
+
         edrvcyclicInstance_l.curTxBufferEntry++;
 
         if (fCallSyncCb_p)
@@ -782,4 +786,4 @@ Exit:
     return ret;
 }
 
-///\}
+/// \}

--- a/stack/src/kernel/edrv/edrvcyclic.c
+++ b/stack/src/kernel/edrv/edrvcyclic.c
@@ -703,18 +703,18 @@ static tOplkError processTxBufferList(BOOL fCallSyncCb_p)
 
         if (fFirstPacket)
         {
-            pTxBuffer->tttx.launchTime = launchTime;
-            pTxBuffer->fTimeTrig = TRUE;
+            pTxBuffer->launchTime.nanoSeconds = launchTime;
+            pTxBuffer->fLaunchTimeValid = TRUE;
             fFirstPacket = FALSE;
         }
         else
         {
             launchTime = launchTime + (UINT64)pTxBuffer->timeOffsetNs;
-            pTxBuffer->tttx.launchTime = launchTime;
-            pTxBuffer->fTimeTrig = TRUE;
+            pTxBuffer->launchTime.nanoSeconds = launchTime;
+            pTxBuffer->fLaunchTimeValid = TRUE;
         }
 
-        if ((pTxBuffer->tttx.launchTime - cycleMin) > (cycleMax - cycleMin))
+        if ((pTxBuffer->launchTime.nanoSeconds - cycleMin) > (cycleMax - cycleMin))
         {
             ret = kErrorEdrvTxListNotFinishedYet;
             goto Exit;
@@ -724,8 +724,8 @@ static tOplkError processTxBufferList(BOOL fCallSyncCb_p)
         if (ret != kErrorOk)
             goto Exit;
 
-        pTxBuffer->tttx.launchTime = 0;
-        pTxBuffer->fTimeTrig = FALSE;
+        pTxBuffer->launchTime.nanoSeconds = 0;
+        pTxBuffer->fLaunchTimeValid = FALSE;
 
         edrvcyclicInstance_l.curTxBufferEntry++;
 


### PR DESCRIPTION
This pull request contains:
- Addition of generic time triggered flag for frames to indicate the difference to the edrv module.
- 2nd Queue implementation in edrv i210 to support send of non-time triggered frames

The above changes enable the edrv-i210 MN driver to support MN and CN in the same binary which was not possible earlier.

Test on:
- APC2100 with on board i210 chip
- Zynq (To verify functionality of the edrv-openmac and edrvcylinc-openmac changes)
- Desktop PC with external i210 NIC


